### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 このModel Context Protocol (MCP) サーバーは、JIRAとの連携機能を提供します。ChatGPTやその他のAIアシスタントがJIRAのイシューを直接操作できるようになります。
 
+<a href="https://glama.ai/mcp/servers/@kuvanov-2/mcp-server-jira">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kuvanov-2/mcp-server-jira/badge" alt="Server for JIRA MCP server" />
+</a>
+
 ## 機能
 
 このMCPサーバーは以下のツールを提供します：


### PR DESCRIPTION
This PR adds a badge for the [MCP Server for JIRA](https://glama.ai/mcp/servers/@kuvanov-2/mcp-server-jira) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kuvanov-2/mcp-server-jira">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kuvanov-2/mcp-server-jira/badge" alt="Server for JIRA MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.